### PR TITLE
Implement Plaid TransactionsSyncRequest

### DIFF
--- a/backend/budgetbox/plaid_app/models.py
+++ b/backend/budgetbox/plaid_app/models.py
@@ -21,9 +21,11 @@ class BankAccount(models.Model):
     )  # last 4 digits of account number
 
     institution_name = models.CharField(max_length=255, blank=True)
-
     is_active = models.BooleanField(default=True)
 
+    # NOTE: Based off of Plaid's documentation, a cursor represents the last update requested by the user.  We must store this for future syncs. Without this, we cannot ensure we don't duplicate transactions
+    sync_cursor = models.TextField(blank=True, null=True)  # Stores Plaid's sync cursor
+    last_synced = models.DateTimeField(blank=True, null=True)  # Track when last synced
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -33,27 +35,40 @@ class BankAccount(models.Model):
     def __str__(self):
         return f"{self.institution_name} {self.account_name} (*{self.mask})"
 
-
 class Transaction(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="transactions"
     )
-
     bank_account = models.ForeignKey(
-        BankAccount, on_delete=models.CASCADE, related_name="transactions", default=1
+        BankAccount, on_delete=models.CASCADE, related_name="transactions"
     )
-
     amount = models.DecimalField(max_digits=10, decimal_places=2)
     merchant_name = models.CharField(max_length=255)
-    date_paid = models.DateField()
-    category = models.CharField(max_length=100, blank=True, default="Uncategorized")
 
-    # prevents duplicate transactions
+    # Use authorized_date as primary field (more accurate than posted date)
+    authorized_date = models.DateField()
+    # Keep date_paid for reference but not required
+    date_paid = models.DateField(blank=True, null=True)
+
+    category = models.CharField(max_length=100, blank=True, default="Uncategorized")
+    
+    # CRITICAL: plaid_transaction_id is the primary key for sync operations
+    # This is how Plaid tracks added/modified/removed transactions in sync responses
     plaid_transaction_id = models.CharField(max_length=255, unique=True)
+    
+    # Store account_id for reference but sync uses plaid_transaction_id for tracking
+    plaid_account_id = models.CharField(max_length=255, blank=True, null=True)
+    
     created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)  # Track when transaction was last modified
 
     class Meta:
-        ordering = ["-date_paid"]
+        ordering = ["-authorized_date"]
+        # I removed complex constraints and let Plaid's sync handle deduplication via transaction_id
+        indexes = [
+            models.Index(fields=['user', 'authorized_date']),
+            models.Index(fields=['plaid_account_id']),
+        ]
 
     def __str__(self):
         return f"{self.merchant_name} - {self.amount}"
@@ -62,7 +77,6 @@ class Transaction(models.Model):
 def create_bank_account_from_plaid(
     user, account_data, access_token, institution_name="Unknown Bank"
 ):
-
     bank_account = BankAccount.objects.create(
         user=user,
         plaid_account_id=account_data["account_id"],
@@ -79,15 +93,25 @@ def create_bank_account_from_plaid(
 
 
 def create_transaction_from_plaid(user, bank_account, transaction_data):
+    """
+    Create transaction from Plaid data - designed for TransactionsSyncRequest
+    
+    The sync endpoint provides transaction_id as the stable identifier,
+    so we use get_or_create with plaid_transaction_id as the lookup field.
+    """
     merchant_name = (
         transaction_data.get("merchant_name")
         or transaction_data.get("name")
         or "Unknown Merchant"
     )
-
     pfc = transaction_data.get("personal_finance_category", {})
     category = pfc.get("primary", "Uncategorized")
 
+    # Use authorized_date as primary, fall back to date if authorized_date is None
+    authorized_date = transaction_data.get("authorized_date") or transaction_data.get("date")
+    date_paid = transaction_data.get("date")  # Keep for reference
+
+    # Use get_or_create with plaid_transaction_id - this is Plaid's recommended approach
     transaction, created = Transaction.objects.get_or_create(
         plaid_transaction_id=transaction_data["transaction_id"],
         defaults={
@@ -95,9 +119,56 @@ def create_transaction_from_plaid(user, bank_account, transaction_data):
             "bank_account": bank_account,
             "amount": abs(transaction_data["amount"]),
             "merchant_name": merchant_name,
-            "date_paid": transaction_data["date"],
+            "authorized_date": authorized_date,
+            "date_paid": date_paid,
+            "plaid_account_id": transaction_data.get("account_id", ""),
             "category": category,
-        },
+        }
     )
-
+    
     return transaction, created
+
+
+def update_transaction_from_plaid(transaction, transaction_data):
+    """
+    Update existing transaction with modified data from Plaid sync
+    
+    This is called for transactions in the 'modified' array from sync response
+    """
+    merchant_name = (
+        transaction_data.get("merchant_name")
+        or transaction_data.get("name") 
+        or "Unknown Merchant"
+    )
+    pfc = transaction_data.get("personal_finance_category", {})
+    category = pfc.get("primary", "Uncategorized")
+    
+    authorized_date = transaction_data.get("authorized_date") or transaction_data.get("date")
+    date_paid = transaction_data.get("date")
+    
+    # Update fields that might have changed
+    transaction.amount = abs(transaction_data["amount"])
+    transaction.merchant_name = merchant_name
+    transaction.authorized_date = authorized_date
+    transaction.date_paid = date_paid
+    transaction.category = category
+    transaction.plaid_account_id = transaction_data.get("account_id", "")
+    
+    transaction.save()
+    return transaction
+
+
+def delete_transaction_from_plaid(transaction_id):
+    """
+    Delete transaction based on Plaid transaction_id
+    
+    This is called for transactions in the 'removed' array from sync response
+    """
+    try:
+        transaction = Transaction.objects.get(plaid_transaction_id=transaction_id)
+        transaction.delete()
+        return True
+    except Transaction.DoesNotExist:
+        # Transaction doesn't exist in our database, which is fine
+        return False
+

--- a/backend/budgetbox/plaid_app/views.py
+++ b/backend/budgetbox/plaid_app/views.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
-
 import plaid
 from django.contrib.auth import get_user_model
 from django.shortcuts import render
+from django.utils import timezone
 from plaid.api import plaid_api
 from plaid.model.accounts_get_request import AccountsGetRequest
 from plaid.model.country_code import CountryCode
@@ -12,7 +11,7 @@ from plaid.model.link_token_create_request import LinkTokenCreateRequest
 from plaid.model.link_token_create_request_user import \
     LinkTokenCreateRequestUser
 from plaid.model.products import Products
-from plaid.model.transactions_get_request import TransactionsGetRequest
+from plaid.model.transactions_sync_request import TransactionsSyncRequest
 from rest_framework import permissions
 from rest_framework import status as s
 from rest_framework import viewsets
@@ -24,7 +23,9 @@ from budgetbox_project.settings import PLAID_CLIENT_ID, PLAID_SANDBOX_KEY
 from clerk_app.models import BudgetBoxUser
 
 from .models import (BankAccount, Transaction, create_bank_account_from_plaid,
-                     create_transaction_from_plaid)
+                     create_transaction_from_plaid,
+                     delete_transaction_from_plaid,
+                     update_transaction_from_plaid)
 
 # Create your views here.
 
@@ -154,10 +155,7 @@ class GetTransactions(APIView):
     @clerk_auth_required
     def get(self, request):
         try:
-            # Fetch the user
             user = BudgetBoxUser.objects.get(clerk_user_id=request.clerk_user_id)
-
-            # Get all active bank accounts for this user
             bank_accounts = user.bank_accounts.filter(is_active=True)
 
             if not bank_accounts.exists():
@@ -166,46 +164,76 @@ class GetTransactions(APIView):
                     status=400
                 )
 
-            start_date = datetime.now() - timedelta(days=30)
-            end_date = datetime.now()
             all_created_transactions = []
 
-            # Loop through each bank account
             for bank_account in bank_accounts:
                 if not bank_account.plaid_access_token:
-                    continue  # skip accounts without a token
+                    continue
 
-                transactions_request = TransactionsGetRequest(
-                    access_token=bank_account.plaid_access_token,
-                    start_date=start_date.date(),
-                    end_date=end_date.date(),
-                )
+                try:
+                    cursor = bank_account.sync_cursor or ""
+                    
+                    # Collect all updates for this account
+                    added = []
+                    modified = []
+                    removed = []
+                    has_more = True
 
-                response = plaid_client.transactions_get(transactions_request)
-                transactions_data = response["transactions"]
+                    # Paginate through all updates
+                    while has_more:
+                        sync_request = TransactionsSyncRequest(
+                            access_token=bank_account.plaid_access_token,
+                            cursor=cursor,
+                            count=500  # Optional: limit per request
+                        )
+                        
+                        response = plaid_client.transactions_sync(sync_request)
+                        
+                        # Collect all updates from this page
+                        added.extend(response.get('added', []))
+                        modified.extend(response.get('modified', []))
+                        removed.extend(response.get('removed', []))
+                        
+                        has_more = response.get('has_more', False)
+                        cursor = response.get('next_cursor')
+                    # Process all added transactions
+                    for transaction_data in added:
+                        transaction, created = create_transaction_from_plaid(
+                            user, bank_account, transaction_data
+                        )
+                        
+                        if created:
+                            all_created_transactions.append({
+                                "id": transaction.id,
+                                "merchant_name": transaction.merchant_name,
+                                "amount": str(transaction.amount),
+                                "authorized_date": str(transaction.authorized_date),
+                                "date_paid": str(transaction.date_paid) if transaction.date_paid else None,
+                                "category": transaction.category,
+                                "account": bank_account.account_name,
+                            })
 
-                for transaction_data in transactions_data:
-                    # Using get_or_create to avoid duplicates
-                    transaction, created = Transaction.objects.get_or_create(
-                        plaid_transaction_id=transaction_data['transaction_id'],
-                        defaults={
-                            "user": user,
-                            "bank_account": bank_account,
-                            "amount": abs(transaction_data['amount']),
-                            "merchant_name": transaction_data.get("merchant_name") or transaction_data.get("name") or "Unknown Merchant",
-                            "date_paid": transaction_data['date'],
-                            "category": transaction_data.get("personal_finance_category", {}).get("primary", "Uncategorized")
-                        }
-                    )
-                    if created:
-                        all_created_transactions.append({
-                            "id": transaction.id,
-                            "merchant_name": transaction.merchant_name,
-                            "amount": str(transaction.amount),
-                            "date_paid": str(transaction.date_paid),
-                            "category": transaction.category,
-                            "account": bank_account.account_name,
-                        })
+                    # Process modified transactions
+                    for transaction_data in modified:
+                        existing_transaction = Transaction.objects.filter(
+                            plaid_transaction_id=transaction_data['transaction_id']
+                        ).first()
+                        
+                        if existing_transaction:
+                            update_transaction_from_plaid(existing_transaction, transaction_data)
+
+                    # Process removed transactions  
+                    for removed_data in removed:
+                        delete_transaction_from_plaid(removed_data['transaction_id'])
+
+                    # Save cursor for next sync
+                    bank_account.sync_cursor = cursor
+                    bank_account.last_synced = timezone.now()
+                    bank_account.save()
+
+                except Exception as account_error:
+                    print(f"Error syncing account {bank_account.account_name}: {account_error}")
+                    continue
 
             return Response({
                 "message": f"Created {len(all_created_transactions)} new transactions",
@@ -218,13 +246,12 @@ class GetTransactions(APIView):
             return Response({"error": str(e)}, status=400)
 
 class ListTransactions(APIView):
-
     @clerk_auth_required
     def get(self, request):
         try:
             user = User.objects.get(clerk_user_id=request.clerk_user_id)
             transactions = user.transactions.all()[:50]  # Last 50 transactions
-
+            
             transaction_data = []
             for transaction in transactions:
                 transaction_data.append(
@@ -232,15 +259,15 @@ class ListTransactions(APIView):
                         "id": transaction.id,
                         "merchant_name": transaction.merchant_name,
                         "amount": str(transaction.amount),
-                        "date_paid": str(transaction.date_paid),
+                        "authorized_date": str(transaction.authorized_date),  # Primary date field
+                        "date_paid": str(transaction.date_paid) if transaction.date_paid else None,  # Optional
                         "category": transaction.category,
                         "created_at": transaction.created_at.isoformat(),
                     }
                 )
-
+            
             return Response(
                 {"transactions": transaction_data, "count": len(transaction_data)}
             )
-
         except Exception as e:
             return Response({"error": str(e)}, status=s.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- Refactored GetTransactions to use TransactionsSyncRequest instead of TransactionsGetRequest  
- Added sync_cursor and last_synced fields to BankAccount model
- Updated Transaction model to use plaid_transaction_id as unique identifier
- Implemented proper pagination through Plaid's has_more flag
- Added helper functions for transaction updates and deletions
- Fixed timezone handling for last_synced timestamps